### PR TITLE
7.x islandora solution pack disk image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: required
 language: php
 php:
   - 5.3.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ before_install:
   - ln -s $HOME/islandora_solution_pack_collection sites/all/modules/islandora_solution_pack_collection
   - drush dl imagemagick
   - drush en --user=1 --yes imagemagick islandora_basic_collection islandora_disk_image
+before_script:
+  # Mysql might time out for long tests, increase the wait timeout.
+  - mysql -e 'SET @@GLOBAL.wait_timeout=1200'
 script:
   - ant -buildfile sites/all/modules/islandora_solution_pack_disk_image/build.xml lint
   - $ISLANDORA_DIR/tests/scripts/line_endings.sh sites/all/modules/islandora_solution_pack_disk_image

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ script:
   - $ISLANDORA_DIR/tests/scripts/line_endings.sh sites/all/modules/islandora_solution_pack_disk_image
   - drush coder-review --reviews=production,security,style,i18n,potx,sniffer islandora_disk_image
   - phpcpd --names *.module,*.inc,*.test sites/all/modules/islandora_solution_pack_disk_image
-  - drush -v test-run --uri=http://localhost:8081 "Islandora Disk Image"
+  - php scripts/run-tests.sh --php `phpenv which php` --url http://localhost:8081 --verbose "Islandora Disk Image"
 after_failure:
   - cat /tmp/drush_webserver.log
   - cd $HOME/drupal-*


### PR DESCRIPTION
JIRA Ticket: https://jira.duraspace.org/browse/ISLANDORA-1880

What does this Pull Request do?

Replaces Travis-CI Drupal Test invocations made via Drush, which are being deprecated, with Drupal's provided PHP scripts. Updates the YAML to have a MySQL timeout so that long running tests don't cause the MySQL session to timeout. Lastly, adds sudo for the YAML as old builds were grandfathered.

What's new?

Modified the .travis.yml file from Drush to the drupal script. Added Sudo in .travis.yml file as it required for the scrips to run, repos before 2015 were grandfathered in. However, this isn't the case for forks. Also, added a before_script in travis.yml file to extend mysql wait time to 1200 as the builds were failing in Travic-ci.org.

Interested parties

@Islandora/7-x-1-x-committers