### PR TITLE
Add new MIME type to the DS-COMPOSITE-MODEL.

### DIFF
--- a/xml/islandora_disk_image_ds_composite_model.xml
+++ b/xml/islandora_disk_image_ds_composite_model.xml
@@ -14,6 +14,7 @@
   </dsTypeModel>
   <dsTypeModel ID="OBJ" optional="true">
     <form MIME="application/octet-stream"/>
+    <form MIME="application/encase"/>
   </dsTypeModel>
   <dsTypeModel ID="TECHMD" optional="true">
     <form MIME="application/xml"/>


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1466

# What does this Pull Request do?
Adds the new MIME type for EnCase files as upload support was added in https://github.com/Islandora/islandora_solution_pack_disk_image/pull/35.

# What's new?
New MIME type entry to the DS-COMPOSITE-MODEL.

# How should this be tested?
Re-install the content model via the required objects page and you have a new entry.

# Interested parties
@mjordan
